### PR TITLE
Fix: Query escape names

### DIFF
--- a/q/query.js
+++ b/q/query.js
@@ -41,6 +41,7 @@ exports = {
             var key = parts.shift(),
                 val = parts.length > 0 ? parts.join('=') : null;
 
+            key = decodeURIComponent(key);
             val = decodeURIComponent(val);
 
             if (isUndef(ret[key]))
@@ -64,7 +65,7 @@ exports = {
             if (isObj(val) && isEmpty(val)) return '';
             if (isArr(val)) return exports.stringify(val, key);
 
-            return (arrKey || key) + '=' + encodeURIComponent(val);
+            return (arrKey ? encodeURIComponent(arrKey) : encodeURIComponent(key)) + '=' + encodeURIComponent(val);
         }), function (str)
         {
             return str.length > 0;

--- a/q/query.test.js
+++ b/q/query.test.js
@@ -8,6 +8,9 @@ it('parse query', function ()
     expect(query.parse('test=1&test=2')).to.eql({
         test: ['1', '2']
     });
+    expect(query.parse('te%20st=te%20st')).to.eql({
+        'te st': 'te st'
+    })
 });
 
 it('stringify query', function ()
@@ -21,4 +24,7 @@ it('stringify query', function ()
     expect(query.stringify({
         test: ['1', '2']
     })).to.equal('test=1&test=2');
+    expect(query.stringify({
+        'te st': 'te st'
+    })).to.equal('te%20st=te%20st')
 });


### PR DESCRIPTION
> Forms submitted with this content type must be encoded as follows:
> 1. **Control names and values are escaped.** Space characters are replaced by `+', and then reserved characters are escaped as described in [RFC1738], section 2.2: Non-alphanumeric characters are replaced by `%HH', a percent sign and two hexadecimal digits representing the ASCII code of the character. Line breaks are represented as "CR LF" pairs (i.e., `%0D%0A').
> 1. The control names/values are listed in the order they appear in the document. The name is separated from the value by `=' and name/value pairs are separated from each other by `&'.

FYI: https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1